### PR TITLE
[49] Refactor tests to use `pytest`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@
 * 58: Cosmetic documentation edits.
 * 56: Update Python dependency to 3.10.
 * 50: Leverage `tox` to run tests.
+* 49: Refactor tests to use `pytest`.
 * 48: Replace `conda` with `hatch`.
 * 39: Update for basic compatibility with Python 3.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 ]
 dependencies = [
   "astropy",
+  "mpmath",
   "numpy",
-  "sympy",
 ]
 dynamic = ["version"]
 

--- a/src/ibei/uibei.py
+++ b/src/ibei/uibei.py
@@ -9,21 +9,56 @@ def uibei(order, energy_lo, temp, chem_potential):
     """
     Upper incomplete Bose-Einstein integral.
 
-    The upper incomplete Bose-Einstein integral is given by (cf. Levy and Honsberg :cite:`10.1016/j.sse.2006.06.017`):
+    The upper incomplete Bose-Einstein integral is given by the following
+    expression [1]_ for condition :math:`\mu < E_{A}`, and is equal to
+    zero when this condition is not met.
 
     .. math::
 
         F_{m}(E_{A},T,\mu) = \\frac{2 \pi}{h^{3}c^{2}} \int_{E_{A}}^{\infty} E^{m} \\frac{1}{\exp \left( \\frac{E - \mu}{kT} \\right) - 1} dE 
 
-    for condition :math:`\mu < E_{A}`; the value of :math:`F_{m}` is zero when the previous condition is not met.
+    The quantities are as follows: :math:`E` is the photon
+    energy, :math:`\mu` is the photon chemical potential, :math:`E_{A}` is
+    the lower limit of integration, :math:`T` is the absolute temperature
+    of the blackbody radiator, :math:`h` is Planck's constant, :math:`c`
+    is the speed of light, :math:`k` is Boltzmann's constant,
+    and :math:`m` is the integer order of the integration. For a value
+    of :math:`m = 2` , this integral returns the photon particle flux,
+    whereas for :math:`m = 3` , the integral yields the photon power
+    flux.
 
-    :param int order: Order of Bose-Einstein integral. A value of 2 yields the particle flux, a value of 3 yields energy flux. Corresponds to :math:`m`.
-    :param float energy_lo: Lower bound of integral > 0 [eV]. Corresponds to :math:`E_{A}`.
-    :param float temp: Temperature of photon ensemble > 0 [K]. Corresponds to :math:`T`.
-    :param float chem_potential: Chemical potential of photon ensemble > 0 [eV]. Corresponds to :math:`\mu`.
-    :rtype: :class:`astropy.units.Quantity`
+    
+    Parameters
+    ----------
+    order: int
+        Order of Bose-Einstein integral. Corresponds to :math:`m`.
+    energy_lo: float or astropy.units.Quantity[units.eV]
+        Lower bound of integral. Corresponds to :math:`E_{A}`.
+    temp: float or astropy.units.Quantity[units.K]
+        Temperature of photon ensemble. Corresponds to :math:`T`.
+    chem_potential: float or astropy.units.Quantity
+        Chemical potential of photon ensemble. Corresponds to:math:`\mu`.
+    
 
-    Note that the float quantities above can also be :class:`astropy.units.Quantity` as long as the units are compatible.
+    Returns
+    -------
+    astropy.units.Quantity
+        Value of upper-incomplete Bose-Einstein integral.
+
+
+    Raises
+    ------
+    ValueError
+        If `energy_lo` <= 0
+    ValueError
+        If `temp` <= 0
+    ValueError
+        If `chem_potential` < 0
+
+
+    References
+    ----------
+    .. [1] :cite:`10.1016/j.sse.2006.06.017`
     """
     if energy_lo < 0:
         raise ValueError("energy_lo < 0")

--- a/test/test_DeVosSolarcell.py
+++ b/test/test_DeVosSolarcell.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 import ibei
-from astropy import units
+import numpy as np
 import unittest
+
+from astropy import units
+
 
 temp_sun = 5762.
 temp_earth = 288.

--- a/test/test_DeVosSolarcell.py
+++ b/test/test_DeVosSolarcell.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import ibei
 import numpy as np
+import pytest
 import unittest
 
 from astropy import units
@@ -15,6 +16,8 @@ input_params = {"temp_sun": temp_sun,
                 "bandgap": bandgap,
                 "voltage": 0.5,}
 
+
+@pytest.mark.xfail(reason="I broke the `DeVosSolarcell` class in a previous commit")
 class Issues(unittest.TestCase):
     """
     Tests output types of the calculator methods.
@@ -35,6 +38,7 @@ class Issues(unittest.TestCase):
             self.fail("Succumbing to issue #3.")
 
 
+@pytest.mark.xfail(reason="I broke the `DeVosSolarcell` class in a previous commit")
 class CalculatorsReturnUnits(unittest.TestCase):
     """
     Tests units of the calculator methods returned values.
@@ -63,6 +67,7 @@ class CalculatorsReturnUnits(unittest.TestCase):
         self.assertEqual(tested_unit, target_unit)
 
 
+@pytest.mark.xfail(reason="I broke the `DeVosSolarcell` class in a previous commit")
 class CalculatorsReturnValue(unittest.TestCase):
     """
     Tests special values of the calculator methods.

--- a/test/test_DeVosSolarcell.py
+++ b/test/test_DeVosSolarcell.py
@@ -77,7 +77,3 @@ class CalculatorsReturnValue(unittest.TestCase):
         """
         self.solarcell.bandgap = 0
         self.assertEqual(0, self.solarcell.calc_power_density())
-
-
-if __name__ == "__main__":
-    pass

--- a/test/test_SBSolarcell.py
+++ b/test/test_SBSolarcell.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 import ibei
-from astropy import units
+import numpy as np
 import unittest
+
+from astropy import units
+
 
 temp_sun = 5762.
 temp_earth = 288.

--- a/test/test_SBSolarcell.py
+++ b/test/test_SBSolarcell.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import ibei
 import numpy as np
+import pytest
 import unittest
 
 from astropy import units
@@ -16,6 +17,7 @@ input_params = {"temp_sun": temp_sun,
                 "voltage": 0.5,}
 
 
+@pytest.mark.xfail(reason="I broke the `SQSolarcell` class in a previous commit")
 class CalculatorsReturnUnits(unittest.TestCase):
     """
     Tests units of the calculator methods returned values.
@@ -52,6 +54,7 @@ class CalculatorsReturnUnits(unittest.TestCase):
         self.assertEqual(tested_unit, target_unit)
 
 
+@pytest.mark.xfail(reason="I broke the `SQSolarcell` class in a previous commit")
 class CalculatorsReturnType(unittest.TestCase):
     """
     Tests type of the calculator methods returned values.
@@ -69,6 +72,7 @@ class CalculatorsReturnType(unittest.TestCase):
         self.assertIsInstance(self.solarcell.calc_efficiency(), float)
 
 
+@pytest.mark.xfail(reason="I broke the `SQSolarcell` class in a previous commit")
 class CalculatorsReturnValue(unittest.TestCase):
     """
     Tests special values of the calculator methods.

--- a/test/test_SBSolarcell.py
+++ b/test/test_SBSolarcell.py
@@ -83,7 +83,3 @@ class CalculatorsReturnValue(unittest.TestCase):
         """
         self.solarcell.bandgap = 0
         self.assertEqual(0, self.solarcell.calc_power_density())
-
-
-if __name__ == "__main__":
-    pass

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -1,45 +1,35 @@
 # -*- coding: utf-8 -*-
 import ibei
-import numpy as np
 import pytest
-import unittest
 
 from astropy import units
+from contextlib import nullcontext as does_not_raise
 
 
-temp_sun = 5762.
-temp_earth = 288.
-bandgap = 1.15
-
-
-class Issues(unittest.TestCase):
+class TestIssues():
     """
-    Tests output types of the calculator methods.
+    Tests corresponding to issues raised due to bugs
     """
     def test_issue_2_uibei(self):
         """
         Refactor of issue 2 focusing on uibei
         """
-        try:
-            ibei.uibei(2, bandgap, temp_sun, 1.2)
-        except:
-            self.fail("Error raised with arguments.")
+        with does_not_raise():
+            ibei.uibei(2, 1.15, 5762., 1.2)
 
     def test_issue_4(self):
         """
         uibei shouldn't fail when energy_lo == chem_potential
         """
-        try:
+        with does_not_raise():
             ibei.uibei(2, 1., 300., 1.)
-        except:
-            self.fail("uibei fails when energy_lo == chem_potential")
 
     def test_issue_31(self):
         """
         Passing `energy_lo=0` with `chem_potential=0` should yield nonzero result
         """
         energy_flux = ibei.uibei(3, 0., 300., 0.)
-        self.assertGreater(energy_flux, 0)
+        assert energy_flux > 0
 
 
 @pytest.mark.parametrize("argname,val", [

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -119,9 +119,6 @@ class TestArgsOutsideConstraints():
             ]
         )
     def test_arg_lt_0(self, valid_quantity_args, argname):
-        """
-        `uibei` should raise `ValueError` for `energy_lo` < 0.
-        """
         invalid_args = valid_quantity_args.copy()
         invalid_args[argname] *= -1
 

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -128,7 +128,3 @@ class CalculatorsArgsOutsideConstraints(unittest.TestCase):
         """
         cp = -1.
         self.assertRaises(ValueError, ibei.uibei, 2, bandgap, temp_sun, cp)
-
-
-if __name__ == "__main__":
-    pass

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -1,13 +1,16 @@
 # -*- coding: utf-8 -*-
 import ibei
 import numpy as np
+import pytest
 import unittest
 
 from astropy import units
 
+
 temp_sun = 5762.
 temp_earth = 288.
 bandgap = 1.15
+
 
 class Issues(unittest.TestCase):
     """
@@ -129,3 +132,18 @@ class CalculatorsArgsOutsideConstraints(unittest.TestCase):
         """
         cp = -1.
         self.assertRaises(ValueError, ibei.uibei, 2, bandgap, temp_sun, cp)
+
+
+@pytest.fixture
+def valid_quantity_args():
+    """
+    Valid arguments for `ibei.uibei` function
+    """
+    args = {
+        "order": 2,
+        "energy_lo": units.Quantity(1.15, units.eV),
+        "temp": units.Quantity(5762., units.K),
+        "chem_potential": units.Quantity(0., units.eV),
+    }
+
+    return args

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -108,24 +108,23 @@ class CalculatorsArgsWrongUnits(unittest.TestCase):
         self.assertRaises(units.UnitsError, ibei.uibei, 2, bandgap, temp_sun, cp)
 
 
-class TestArgsOutsideConstraints():
+@pytest.mark.parametrize("argname", [
+        "energy_lo",
+        "temp",
+        "chem_potential",
+        ]
+    )
+def test_arg_lt_0(valid_quantity_args, argname):
     """
     Tests calling with args are outside constraints.
     """
-    @pytest.mark.parametrize("argname", [
-            "energy_lo",
-            "temp",
-            "chem_potential",
-            ]
-        )
-    def test_arg_lt_0(self, valid_quantity_args, argname):
-        invalid_args = valid_quantity_args.copy()
-        invalid_args[argname] *= -1
+    invalid_args = valid_quantity_args.copy()
+    invalid_args[argname] *= -1
 
-        assert invalid_args[argname] < 0
+    assert invalid_args[argname] < 0
 
-        with pytest.raises(ValueError):
-            val = ibei.uibei(**invalid_args)
+    with pytest.raises(ValueError):
+        val = ibei.uibei(**invalid_args)
 
 
 @pytest.fixture

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -107,11 +107,11 @@ def test_arg_incompatible_unit(valid_quantity_args, argname, val):
             "chem_potential",
         ]
     )
-def test_arg_lt_0(valid_quantity_args, argname):
+def test_arg_lt_0(valid_args, argname):
     """
     Arguments outside constraints raise `ValueError`
     """
-    invalid_args = valid_quantity_args.copy()
+    invalid_args = valid_args.copy()
     invalid_args[argname] *= -1
 
     assert invalid_args[argname] < 0
@@ -120,6 +120,8 @@ def test_arg_lt_0(valid_quantity_args, argname):
         val = ibei.uibei(**invalid_args)
 
 
+# Pytest fixture definitions
+# ==========================
 @pytest.fixture
 def valid_quantity_args():
     """
@@ -131,5 +133,12 @@ def valid_quantity_args():
         "temp": units.Quantity(5762., units.K),
         "chem_potential": units.Quantity(0.5, units.eV),
     }
+
+    return args
+
+
+@pytest.fixture(params=[(lambda x: x), (lambda x: getattr(x, "value", x))])
+def valid_args(request, valid_quantity_args):
+    args = {key: request.param(val) for key, val in valid_quantity_args.items()}
 
     return args

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -102,14 +102,14 @@ def test_arg_incompatible_unit(valid_quantity_args, argname, val):
 
 
 @pytest.mark.parametrize("argname", [
-        "energy_lo",
-        "temp",
-        "chem_potential",
+            "energy_lo",
+            "temp",
+            "chem_potential",
         ]
     )
 def test_arg_lt_0(valid_quantity_args, argname):
     """
-    Tests calling with args are outside constraints.
+    Arguments outside constraints raise `ValueError`
     """
     invalid_args = valid_quantity_args.copy()
     invalid_args[argname] *= -1

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -108,35 +108,24 @@ class CalculatorsArgsWrongUnits(unittest.TestCase):
         self.assertRaises(units.UnitsError, ibei.uibei, 2, bandgap, temp_sun, cp)
 
 
-class CalculatorsArgsOutsideConstraints(unittest.TestCase):
-    """
-    Tests calling with args are outside constraints.
-    """
-    def test_uibei_temp(self):
-        """
-        uibei should raise UnitsError for temp values < 0.
-        """
-        temp = -1.
-        self.assertRaises(ValueError, ibei.uibei, 2, bandgap, temp, 0.)
-
-    def test_uibei_chem_potential(self):
-        """
-        uibei should raise UnitsError for chem_potential values < 0.
-        """
-        cp = -1.
-        self.assertRaises(ValueError, ibei.uibei, 2, bandgap, temp_sun, cp)
-
-
 class TestArgsOutsideConstraints():
     """
     Tests calling with args are outside constraints.
     """
-    def test_energy_lo_lt_0(self, valid_quantity_args):
+    @pytest.mark.parametrize("argname", [
+            "energy_lo",
+            "temp",
+            "chem_potential",
+            ]
+        )
+    def test_arg_lt_0(self, valid_quantity_args, argname):
         """
         `uibei` should raise `ValueError` for `energy_lo` < 0.
         """
         invalid_args = valid_quantity_args.copy()
-        invalid_args["energy_lo"] *= -1
+        invalid_args[argname] *= -1
+
+        assert invalid_args[argname] < 0
 
         with pytest.raises(ValueError):
             val = ibei.uibei(**invalid_args)
@@ -151,7 +140,7 @@ def valid_quantity_args():
         "order": 2,
         "energy_lo": units.Quantity(1.15, units.eV),
         "temp": units.Quantity(5762., units.K),
-        "chem_potential": units.Quantity(0., units.eV),
+        "chem_potential": units.Quantity(0.5, units.eV),
     }
 
     return args

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -82,30 +82,23 @@ class CalculatorsArgsWrongType(unittest.TestCase):
         self.assertRaises(TypeError, ibei.uibei, [2, bandgap, temp_sun, cp])
 
 
-class CalculatorsArgsWrongUnits(unittest.TestCase):
+@pytest.mark.parametrize("argname,val", [
+            ("energy_lo", units.s),
+            ("temp", units.s),
+            ("chem_potential", units.s),
+        ]
+    )
+def test_arg_incompatible_unit(valid_quantity_args, argname, val):
     """
-    Tests calling with args with incorrect units.
+    Incompatible units raise `astropy.units.UnitConversionError`
     """
-    def test_uibei_energy_lo(self):
-        """
-        uibei should raise UnitsError for energy_lo with units not energy.
-        """
-        energy_lo = units.Quantity(1.)
-        self.assertRaises(units.UnitsError, ibei.uibei, 2, energy_lo, temp_sun, 0.)
+    valid_arg_value = valid_quantity_args[argname].value
 
-    def test_uibei_temp(self):
-        """
-        uibei should raise UnitsError for temp with units not temperature.
-        """
-        temp = units.Quantity(1.)
-        self.assertRaises(units.UnitsError, ibei.uibei, 2, bandgap, temp, 0.)
+    invalid_args = valid_quantity_args.copy()
+    invalid_args[argname] = units.Quantity(valid_arg_value, val)
 
-    def test_uibei_chem_potential(self):
-        """
-        uibei should raise UnitsError for chem_potential with units not energy.
-        """
-        cp = units.Quantity(1.)
-        self.assertRaises(units.UnitsError, ibei.uibei, 2, bandgap, temp_sun, cp)
+    with pytest.raises(units.UnitConversionError):
+        val = ibei.uibei(**invalid_args)
 
 
 @pytest.mark.parametrize("argname", [

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import numpy as np
 import ibei
-from astropy import units
+import numpy as np
 import unittest
+
+from astropy import units
 
 temp_sun = 5762.
 temp_earth = 288.

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -42,46 +42,6 @@ class Issues(unittest.TestCase):
         self.assertGreater(energy_flux, 0)
 
 
-class CalculatorsArgsWrongType(unittest.TestCase):
-    """
-    Tests calling with args of invalid type.
-    """
-    def test_uibei_order_nonint(self):
-        """
-        uibei should raise TypeError for non-int order.
-        """
-        order = "not even numeric"
-        self.assertRaises(TypeError, ibei.uibei, [order, bandgap, temp_sun, 0.])
-
-    def test_uibei_order_float(self):
-        """
-        uibei should raise TypeError for order of type float.
-        """
-        order = 2.3
-        self.assertRaises(TypeError, ibei.uibei, [order, bandgap, temp_sun, 0.])
-
-    def test_uibei_energy_lo_nonnumeric(self):
-        """
-        uibei should raise TypeError for non-numeric energy_lo.
-        """
-        energy_lo = "non numeric"
-        self.assertRaises(TypeError, ibei.uibei, [2, energy_lo, temp_sun, 0.])
-
-    def test_uibei_temp_nonnumeric(self):
-        """
-        uibei should raise TypeError for non-numeric temp.
-        """
-        temp = "non numeric"
-        self.assertRaises(TypeError, ibei.uibei, [2, bandgap, temp, 0.])
-
-    def test_uibei_chem_potential_nonnumeric(self):
-        """
-        uibei should raise TypeError for non-numeric chem_potential.
-        """
-        cp = "non numeric"
-        self.assertRaises(TypeError, ibei.uibei, [2, bandgap, temp_sun, cp])
-
-
 @pytest.mark.parametrize("argname,val", [
             ("energy_lo", units.s),
             ("temp", units.s),

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -112,13 +112,6 @@ class CalculatorsArgsOutsideConstraints(unittest.TestCase):
     """
     Tests calling with args are outside constraints.
     """
-    def test_uibei_energy_lo(self):
-        """
-        uibei should raise UnitsError for energy_lo values < 0.
-        """
-        energy_lo = -1.
-        self.assertRaises(ValueError, ibei.uibei, 2, energy_lo, temp_sun, 0.)
-
     def test_uibei_temp(self):
         """
         uibei should raise UnitsError for temp values < 0.
@@ -132,6 +125,21 @@ class CalculatorsArgsOutsideConstraints(unittest.TestCase):
         """
         cp = -1.
         self.assertRaises(ValueError, ibei.uibei, 2, bandgap, temp_sun, cp)
+
+
+class TestArgsOutsideConstraints():
+    """
+    Tests calling with args are outside constraints.
+    """
+    def test_energy_lo_lt_0(self, valid_quantity_args):
+        """
+        `uibei` should raise `ValueError` for `energy_lo` < 0.
+        """
+        invalid_args = valid_quantity_args.copy()
+        invalid_args["energy_lo"] *= -1
+
+        with pytest.raises(ValueError):
+            val = ibei.uibei(**invalid_args)
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview
This PR closes #49.


# Deliverables
* [x] Update tests to use `pytest` instead of `unittest`.
* [x] Remove any references to `nose`.
* [x] Reorganize tests as necessary.
* [x] Mark tests for `DeVosSolarcell` and `SBSolarcell` as `skip` or `xfail`.
* [ ] Update any dependencies that are needed (currently I have an explicit dependency on `sympy` in `pyproject.toml` and I think it should be an explicit dependency on `mpmath`).
* [x] All tests for `ibei.uibei` must pass before merging this PR.

Refactoring tests for `DeVosSolarcell` and `SBSolarcell` to use `pytest` are out of scope for this PR and corresponding ticket. I will eventually deal with those two as part of release `2.0.0`, but I will do so in another ticket/PR.