### PR TITLE
[51] Add GitHub action to build package and run tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,35 @@
+name: Build and test package
+
+on:
+  workflow_call:
+  push:
+
+jobs:
+  build_test:
+    env:
+      IBEI_TOX_DISTDIR_PATH_PATH: ${{ github.workspace }}/tox_distdir_path.txt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install tox
+
+      - name: Run tests and extract location of package artifact parent directory
+        run: |
+          tox -e github
+          echo "IBEI_TOX_DISTDIR_PATH=$(cat $IBEI_TOX_DISTDIR_PATH_PATH)" >> $GITHUB_ENV
+
+      - name: Upload package
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ${{ env.IBEI_TOX_DISTDIR_PATH }}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 =====
 * 58: Cosmetic documentation edits.
 * 56: Update Python dependency to 3.10.
+* 51: Write GitHub action to automatically run tests.
 * 50: Leverage `tox` to run tests.
 * 49: Refactor tests to use `pytest`.
 * 48: Replace `conda` with `hatch`.

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -6,6 +6,13 @@ from astropy import units
 from contextlib import nullcontext as does_not_raise
 
 
+def test_fail():
+    """
+    This test will fail
+    """
+    assert False
+
+
 class TestIssues():
     """
     Tests corresponding to issues raised due to bugs

--- a/test/test_uiebi.py
+++ b/test/test_uiebi.py
@@ -6,13 +6,6 @@ from astropy import units
 from contextlib import nullcontext as does_not_raise
 
 
-def test_fail():
-    """
-    This test will fail
-    """
-    assert False
-
-
 class TestIssues():
     """
     Tests corresponding to issues raised due to bugs

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,17 @@ isolated_build = True
 
 
 [testenv]
+allowlist_externals =
+    sh
+
 commands = 
     pytest
+
+commands_post =
+    github: sh -c 'echo "{distdir}" > $IBEI_TOX_DISTDIR_PATH_PATH'
+
+passenv =
+    github: IBEI_TOX_DISTDIR_PATH_PATH
 
 deps =
     pytest


### PR DESCRIPTION
# Overview
This PR closes #51. The corresponding ticket doesn't mention this feature, but the GH action in this PR will also upload the resulting build artifacts.


# Deliverables
* [x] GitHub action to build package and run tests.
* [x] PRs are blocked unless all tests pass.