### PR TITLE
[43] Add method to compute full Bose-Einstein integral

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * 50: Leverage `tox` to run tests.
 * 49: Refactor tests to use `pytest`.
 * 48: Replace `conda` with `hatch`.
+* 43: Add method to compute full Bose-Einstein integral.
 * 39: Update for basic compatibility with Python 3.
 
 

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -199,15 +199,15 @@ class BEI():
 
     @property
     def _kT(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
-        return self.temperature * astropy.constants.k_B
+        return (self.temperature * astropy.constants.k_B).decompose()
 
     @property
     def _reduced_energy_bound(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
-        return self.energy_bound / self._kT
+        return (self.energy_bound / self._kT).decompose()
 
     @property
     def _reduced_chemical_potential(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
-        return self.chemical_potential / self._kT
+        return (self.chemical_potential / self._kT).decompose()
 
     @property
     def _prefactor(self) -> astropy.units.Quantity:

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -185,7 +185,16 @@ class BEI():
         astropy.units.Quantity
             Value of the Bose-Einstein integral.
         """
-        pass
+        expt = self._reduced_chemical_potential.decompose()
+        real_arg = np.exp(expt.value)
+
+        if self._reduced_chemical_potential > 0:
+            bei = 0 * self._prefactor
+
+        else:
+            bei = self._prefactor * mpmath.gamma(self.order + 1) * mpmath.polylog(self.order + 1, real_arg)
+
+        return bei
 
 
     @property

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -197,6 +197,21 @@ class BEI():
         return bei
 
 
+    def photon_flux(self) -> astropy.units.Quantity["1/(m*2 s)"]:
+        """
+        Number of photons radiated per unit time per unit area.
+
+        Notes
+        -----
+        This convenience method is a special case of `BEI.full`. This method
+        assumes the value of `order` is 3.
+        """
+        flux = (4 * np.pi * mpmath.zeta(3) * self.kT**3) / \
+            (astropy.constants.h**3 * astropy.constants.c**2)
+
+        return flux.to("1/(m*2 s)")
+
+
     def radiant_power_flux(self) -> astropy.units.Quantity["J/(m*2 s)"]:
         """
         Energy radiated per unit time per unit area.

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -157,10 +157,10 @@ class BEI():
         if self._reduced_chemical_potential == 0 and self._reduced_energy_bound == 0:
             # Specify this condition just to skip the next condition.
             term = float(mpmath.polylog(self.order + 1, real_arg))
-            bei = term * self._prefactor * np.math.factorial(self.order) 
+            bei = term * self._prefactor * np.math.factorial(self.order)
 
         elif self._reduced_chemical_potential >= self._reduced_energy_bound:
-            bei = 0 * self._prefactor * np.math.factorial(self.order) 
+            bei = 0 * self._prefactor * np.math.factorial(self.order)
 
         else:
             summand = 0
@@ -171,7 +171,7 @@ class BEI():
 
                 summand += term
 
-            bei = self._prefactor * summand * np.math.factorial(self.order) 
+            bei = self._prefactor * summand * np.math.factorial(self.order)
 
         return bei
 

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -151,27 +151,27 @@ class BEI():
         ----------
         .. [1] :cite:`10.1016/j.sse.2006.06.017`
         """
-        expt = self._reduced_chemical_potential - self._reduced_energy_bound
+        expt = self.reduced_chemical_potential - self.reduced_energy_bound
         real_arg = np.exp(expt.value)
 
-        if self._reduced_chemical_potential == 0 and self._reduced_energy_bound == 0:
+        if self.reduced_chemical_potential == 0 and self.reduced_energy_bound == 0:
             # Specify this condition just to skip the next condition.
             term = float(mpmath.polylog(self.order + 1, real_arg))
-            bei = term * self._prefactor * np.math.factorial(self.order)
+            bei = term * self.prefactor * np.math.factorial(self.order)
 
-        elif self._reduced_chemical_potential >= self._reduced_energy_bound:
-            bei = 0 * self._prefactor * np.math.factorial(self.order)
+        elif self.reduced_chemical_potential >= self.reduced_energy_bound:
+            bei = 0 * self.prefactor * np.math.factorial(self.order)
 
         else:
             summand = 0
             for indx in range(1, self.order + 2):
                 index = self.order - indx + 1
 
-                term = self._reduced_energy_bound**index * float(mpmath.polylog(indx, real_arg)) / np.math.factorial(index)
+                term = self.reduced_energy_bound**index * float(mpmath.polylog(indx, real_arg)) / np.math.factorial(index)
 
                 summand += term
 
-            bei = self._prefactor * summand * np.math.factorial(self.order)
+            bei = self.prefactor * summand * np.math.factorial(self.order)
 
         return bei
 
@@ -185,32 +185,48 @@ class BEI():
         astropy.units.Quantity
             Value of the Bose-Einstein integral.
         """
-        expt = self._reduced_chemical_potential
+        expt = self.reduced_chemical_potential
         real_arg = np.exp(expt.value)
 
-        if self._reduced_chemical_potential > 0:
-            bei = 0 * self._prefactor
+        if self.reduced_chemical_potential > 0:
+            bei = 0 * self.prefactor
 
         else:
-            bei = self._prefactor * mpmath.gamma(self.order + 1) * mpmath.polylog(self.order + 1, real_arg)
+            bei = self.prefactor * mpmath.gamma(self.order + 1) * mpmath.polylog(self.order + 1, real_arg)
 
         return bei
 
 
     @property
-    def _kT(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
+    def kT(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
+        """
+        Product of Boltzmann's constant and temperature.
+        """
         return (self.temperature * astropy.constants.k_B).decompose()
 
     @property
-    def _reduced_energy_bound(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
-        return (self.energy_bound / self._kT).decompose()
+    def reduced_energy_bound(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
+        """
+        Dimensionless energy bound in units of kT.
+        """
+        return (self.energy_bound / self.kT).decompose()
 
     @property
-    def _reduced_chemical_potential(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
-        return (self.chemical_potential / self._kT).decompose()
+    def reduced_chemical_potential(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
+        """
+        Dimensionless chemical potential in units of kT.
+        """
+        return (self.chemical_potential / self.kT).decompose()
 
     @property
-    def _prefactor(self) -> astropy.units.Quantity:
-        return (2 * np.pi * self._kT**(self.order + 1)) / \
+    def prefactor(self) -> astropy.units.Quantity:
+        """
+        Factor preceding Bose-Einstein integral integration result.
+
+        Note
+        ----
+        For `order=3`, this factor is equal to the Stefan-Boltzmann constant.
+        """
+        return (2 * np.pi * self.kT**(self.order + 1)) / \
             (astropy.constants.h**3 * astropy.constants.c**2)
 

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -182,3 +182,15 @@ class BEI():
             bei = prefactor * summand
 
         return bei
+
+
+    def full(self) -> astropy.units.Quantity:
+        """
+        Full Bose-Einstein integral.
+
+        Returns
+        -------
+        astropy.units.Quantity
+            Value of the Bose-Einstein integral.
+        """
+        pass

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -197,6 +197,21 @@ class BEI():
         return bei
 
 
+    def radiant_power_flux(self) -> astropy.units.Quantity["J/(m*2 s)"]:
+        """
+        Energy radiated per unit time per unit area.
+
+        Notes
+        -----
+        This convenience method implements the Stefan-Boltzmann law and is a
+        special case of the `BEI.full`. This method assumes the value of
+        `order` is 3.
+        """
+        power_flux = astropy.constant.sigma_sb * self.temperature**4
+
+        return power_flux.to("J/(m*2 s)")
+
+
     @property
     def kT(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
         """
@@ -230,4 +245,3 @@ class BEI():
         """
         return (2 * np.pi * self.kT**(self.order + 1)) / \
             (astropy.constants.h**3 * astropy.constants.c**2)
-

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -192,7 +192,7 @@ class BEI():
             bei = 0 * self.prefactor
 
         else:
-            bei = self.prefactor * mpmath.gamma(self.order + 1) * mpmath.polylog(self.order + 1, real_arg)
+            bei = self.prefactor * float(mpmath.gamma(self.order + 1)) * float(mpmath.polylog(self.order + 1, real_arg))
 
         return bei
 
@@ -206,7 +206,7 @@ class BEI():
         This convenience method is a special case of `BEI.full`. This method
         assumes the value of `order` is 3.
         """
-        flux = (4 * np.pi * mpmath.zeta(3) * self.kT**3) / \
+        flux = (4 * np.pi * float(mpmath.zeta(3)) * self.kT**3) / \
             (astropy.constants.h**3 * astropy.constants.c**2)
 
         return flux.to("1/(m2 s)")

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -225,7 +225,8 @@ class BEI():
 
         Note
         ----
-        For `order=3`, this factor is equal to the Stefan-Boltzmann constant.
+        For `order=3`, this factor is NOT equal to the Stefan-Boltzmann
+        constant. This factor is missing the Riemann-Zeta term.
         """
         return (2 * np.pi * self.kT**(self.order + 1)) / \
             (astropy.constants.h**3 * astropy.constants.c**2)

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -151,7 +151,7 @@ class BEI():
         ----------
         .. [1] :cite:`10.1016/j.sse.2006.06.017`
         """
-        expt = (self._reduced_chemical_potential - self._reduced_energy_bound).decompose()
+        expt = self._reduced_chemical_potential - self._reduced_energy_bound
         real_arg = np.exp(expt.value)
 
         if self._reduced_chemical_potential == 0 and self._reduced_energy_bound == 0:
@@ -185,7 +185,7 @@ class BEI():
         astropy.units.Quantity
             Value of the Bose-Einstein integral.
         """
-        expt = self._reduced_chemical_potential.decompose()
+        expt = self._reduced_chemical_potential
         real_arg = np.exp(expt.value)
 
         if self._reduced_chemical_potential > 0:

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -151,35 +151,27 @@ class BEI():
         ----------
         .. [1] :cite:`10.1016/j.sse.2006.06.017`
         """
-        kT = self.temperature * astropy.constants.k_B
-
-        reduced_energy_bound = self.energy_bound / kT
-        reduced_chemical_potential = self.chemical_potential / kT
-
-        prefactor = (2 * np.pi * np.math.factorial(self.order) * kT**(self.order + 1)) / \
-            (astropy.constants.h**3 * astropy.constants.c**2)
-
-        expt = (reduced_chemical_potential - reduced_energy_bound).decompose()
+        expt = (self._reduced_chemical_potential - self._reduced_energy_bound).decompose()
         real_arg = np.exp(expt.value)
 
-        if reduced_chemical_potential == 0 and reduced_energy_bound == 0:
+        if self._reduced_chemical_potential == 0 and self._reduced_energy_bound == 0:
             # Specify this condition just to skip the next condition.
             term = float(mpmath.polylog(self.order + 1, real_arg))
-            bei = term * prefactor
+            bei = term * self._prefactor * np.math.factorial(self.order) 
 
-        elif reduced_chemical_potential >= reduced_energy_bound:
-            bei = 0 * prefactor
+        elif self._reduced_chemical_potential >= self._reduced_energy_bound:
+            bei = 0 * self._prefactor * np.math.factorial(self.order) 
 
         else:
             summand = 0
             for indx in range(1, self.order + 2):
                 index = self.order - indx + 1
 
-                term = reduced_energy_bound**index * float(mpmath.polylog(indx, real_arg)) / np.math.factorial(index)
+                term = self._reduced_energy_bound**index * float(mpmath.polylog(indx, real_arg)) / np.math.factorial(index)
 
                 summand += term
 
-            bei = prefactor * summand
+            bei = self._prefactor * summand * np.math.factorial(self.order) 
 
         return bei
 
@@ -194,3 +186,22 @@ class BEI():
             Value of the Bose-Einstein integral.
         """
         pass
+
+
+    @property
+    def _kT(self):
+        return self.temperature * astropy.constants.k_B
+
+    @property
+    def _reduced_energy_bound(self):
+        return self.energy_bound / self._kT
+
+    @property
+    def _reduced_chemical_potential(self):
+        return self.chemical_potential / self._kT
+
+    @property
+    def _prefactor(self):
+        return (2 * np.pi * self._kT**(self.order + 1)) / \
+            (astropy.constants.h**3 * astropy.constants.c**2)
+

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -204,7 +204,7 @@ class BEI():
         Notes
         -----
         This convenience method is a special case of `BEI.full`. This method
-        assumes the value of `order` is 3.
+        assumes the value of `order` is 2.
         """
         flux = (4 * np.pi * float(mpmath.zeta(3)) * self.kT**3) / \
             (astropy.constants.h**3 * astropy.constants.c**2)

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -198,19 +198,19 @@ class BEI():
 
 
     @property
-    def _kT(self):
+    def _kT(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
         return self.temperature * astropy.constants.k_B
 
     @property
-    def _reduced_energy_bound(self):
+    def _reduced_energy_bound(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
         return self.energy_bound / self._kT
 
     @property
-    def _reduced_chemical_potential(self):
+    def _reduced_chemical_potential(self) -> astropy.units.Quantity[astropy.units.dimensionless_unscaled]:
         return self.chemical_potential / self._kT
 
     @property
-    def _prefactor(self):
+    def _prefactor(self) -> astropy.units.Quantity:
         return (2 * np.pi * self._kT**(self.order + 1)) / \
             (astropy.constants.h**3 * astropy.constants.c**2)
 

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -197,7 +197,7 @@ class BEI():
         return bei
 
 
-    def photon_flux(self) -> astropy.units.Quantity["1/(m*2 s)"]:
+    def photon_flux(self) -> astropy.units.Quantity[astropy.units.Unit("1/(m2 s)")]:
         """
         Number of photons radiated per unit time per unit area.
 
@@ -209,10 +209,10 @@ class BEI():
         flux = (4 * np.pi * mpmath.zeta(3) * self.kT**3) / \
             (astropy.constants.h**3 * astropy.constants.c**2)
 
-        return flux.to("1/(m*2 s)")
+        return flux.to("1/(m2 s)")
 
 
-    def radiant_power_flux(self) -> astropy.units.Quantity["J/(m*2 s)"]:
+    def radiant_power_flux(self) -> astropy.units.Quantity[astropy.units.Unit("J/(m2 s)")]:
         """
         Energy radiated per unit time per unit area.
 
@@ -222,9 +222,9 @@ class BEI():
         special case of the `BEI.full`. This method assumes the value of
         `order` is 3.
         """
-        power_flux = astropy.constant.sigma_sb * self.temperature**4
+        power_flux = astropy.constants.sigma_sb * self.temperature**4
 
-        return power_flux.to("J/(m*2 s)")
+        return power_flux.to("J/(m2 s)")
 
 
     @property

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -297,7 +297,12 @@ def test_methods_regression(args, method_under_test, expected_output):
     This test tests each of the methods of a `BEI` instance at least once.
     """
     bei = ibei.models.BEI(**args)
-    output = getattr(bei, method_under_test)()
+    method = getattr(bei, method_under_test)
+
+    if callable(method):
+        output = method()
+    else:
+        output = method
 
     assert astropy.units.allclose(expected_output, output)
 

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -226,6 +226,16 @@ class TestIssues():
                 "full",
                 astropy.units.Quantity(459.30032795, "W/m2"),
             ),
+            (
+                {
+                    "order": 2,
+                    "energy_bound": 1.1,
+                    "temperature": 300,
+                    "chemical_potential": 0,
+                },
+                "radiant_power_flux",
+                astropy.units.Quantity(459.30032795, "W/m2"),
+            ),
         ]
     )
 def test_methods_regression(args, method_under_test, expected_output):

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -216,6 +216,16 @@ class TestIssues():
                 "upper",
                 astropy.units.Quantity(10549122.240303338, "1/(m2 s)"),
             ),
+            (
+                {
+                    "order": 3,
+                    "energy_bound": 1.1,
+                    "temperature": 300,
+                    "chemical_potential": 0,
+                },
+                "full",
+                astropy.units.Quantity(459.30032795, "W/m2"),
+            ),
         ]
     )
 def test_methods_regression(args, method_under_test, expected_output):

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -237,7 +237,12 @@ def test_methods_regression(args, method_under_test, expected_output):
             (3, "J/(m2 s)"),
         ]
     )
-@pytest.mark.parametrize("method_under_test", ("upper",))
+@pytest.mark.parametrize("method_under_test", 
+        (
+            "upper",
+            "full",
+        )
+    )
 def test_methods_units(order, expected_unit, method_under_test, valid_constructor_quantity_args):
     """
     Methods' units should match known units for low orders

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -338,6 +338,17 @@ def test_methods_units(order, expected_unit, method_under_test, valid_constructo
     assert output.unit.is_equivalent(expected_unit)
 
 
+def test_consistency_upper_and_full_methods(valid_constructor_quantity_args):
+    """
+    When `energy_bound` is 0, `BEI.upper` should equal `BEI.full`.
+    """
+    valid_constructor_quantity_args["energy_bound"] = 0
+
+    bei = ibei.models.BEI(**valid_constructor_quantity_args)
+
+    assert astropy.units.allclose(bei.upper(), bei.full())
+
+
 # Pytest fixture definitions
 # ==========================
 @pytest.fixture

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -354,7 +354,7 @@ def test_consistency_upper_and_full_methods(valid_constructor_quantity_args):
             (3, "radiant_power_flux"),
         ]
     )
-def test_consistency_full_and_helper_methods(valid_constructor_quantity_args, order, helper_method_name):
+def test_consistency_full_and_helper_methods(order, helper_method_name, valid_constructor_quantity_args):
     """
     `BEI.full` should equal `BEI.photon_flux` and `BEI.radiant_power_flux` for order 2 and 3, respectively.
 

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -233,8 +233,58 @@ class TestIssues():
                     "temperature": 300,
                     "chemical_potential": 0,
                 },
+                "photon_flux",
+                astropy.units.Quantity(4.1052443203614687e+22, "1/(m2 s)"),
+            ),
+            (
+                {
+                    "order": 2,
+                    "energy_bound": 1.1,
+                    "temperature": 300,
+                    "chemical_potential": 0,
+                },
                 "radiant_power_flux",
                 astropy.units.Quantity(459.30032795, "W/m2"),
+            ),
+            (
+                {
+                    "order": 2,
+                    "energy_bound": 1.1,
+                    "temperature": 300,
+                    "chemical_potential": 0,
+                },
+                "kT",
+                astropy.units.Quantity(4.141947e-21, "J"),
+            ),
+            (
+                {
+                    "order": 2,
+                    "energy_bound": 1.1,
+                    "temperature": 300,
+                    "chemical_potential": 0,
+                },
+                "reduced_energy_bound",
+                astropy.units.Quantity(42.54989978, astropy.units.dimensionless_unscaled),
+            ),
+            (
+                {
+                    "order": 2,
+                    "energy_bound": 2.1,
+                    "temperature": 300,
+                    "chemical_potential": 1.1,
+                },
+                "reduced_chemical_potential",
+                astropy.units.Quantity(42.54989978, astropy.units.dimensionless_unscaled),
+            ),
+            (
+                {
+                    "order": 2,
+                    "energy_bound": 1.1,
+                    "temperature": 300,
+                    "chemical_potential": 0,
+                },
+                "prefactor",
+                astropy.units.Quantity(1.70759151e+22, "1/(m2 s)"),
             ),
         ]
     )

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -357,12 +357,17 @@ def test_consistency_upper_and_full_methods(valid_constructor_quantity_args):
 def test_consistency_full_and_helper_methods(valid_constructor_quantity_args, order, helper_method_name):
     """
     `BEI.full` should equal `BEI.photon_flux` and `BEI.radiant_power_flux` for order 2 and 3, respectively.
+
+    Notes
+    -----
+    This condition holds as long as `chemical_potential` equals zero.
     """
     valid_constructor_quantity_args["order"] = order
+    valid_constructor_quantity_args["chemical_potential"] = 0.
     bei = ibei.models.BEI(**valid_constructor_quantity_args)
     output = getattr(bei, helper_method_name)()
 
-    assert astropy.units.allclose(bei.upper(), output)
+    assert astropy.units.allclose(bei.full(), output)
 
 
 # Pytest fixture definitions

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -349,6 +349,22 @@ def test_consistency_upper_and_full_methods(valid_constructor_quantity_args):
     assert astropy.units.allclose(bei.upper(), bei.full())
 
 
+@pytest.mark.parametrize("order,helper_method_name",[
+            (2, "photon_flux"),
+            (3, "radiant_power_flux"),
+        ]
+    )
+def test_consistency_full_and_helper_methods(valid_constructor_quantity_args, order, helper_method_name):
+    """
+    `BEI.full` should equal `BEI.photon_flux` and `BEI.radiant_power_flux` for order 2 and 3, respectively.
+    """
+    valid_constructor_quantity_args["order"] = order
+    bei = ibei.models.BEI(**valid_constructor_quantity_args)
+    output = getattr(bei, helper_method_name)()
+
+    assert astropy.units.allclose(bei.upper(), output)
+
+
 # Pytest fixture definitions
 # ==========================
 @pytest.fixture


### PR DESCRIPTION
# Overview
This PR closes #43.


# Deliverables
* [x] Method to compute full Bose-Einstein integral called `BEI.full`.
* [x] Add regression test for this method.
* [x] Include this method in `test_methods_units`.
* [x] Use type hints.
* [x] Include method to compute [radiant exitance](https://en.m.wikipedia.org/wiki/Radiant_exitance) given by the [Stefan-Boltzmann law](https://en.m.wikipedia.org/wiki/Stefan%E2%80%93Boltzmann_law). This method can serve as a check on the `full` method.
* [x] Include method to compute number of photons per unit area, similar in purpose to the radiant exitance method listed above.