### PR TITLE
[44] Add method to compute lower incomplete Bose-Einstein integral

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@
 * 50: Leverage `tox` to run tests.
 * 49: Refactor tests to use `pytest`.
 * 48: Replace `conda` with `hatch`.
+* 44: Add method to compute lower Bose-Einstein integral.
 * 43: Add method to compute full Bose-Einstein integral.
 * 39: Update for basic compatibility with Python 3.
 

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -118,6 +118,20 @@ class BEI():
         )
 
 
+    def lower(self) -> astropy.units.Quantity:
+        """
+        Lower incomplete Bose-Einstein integral.
+
+        Returns
+        -------
+        astropy.units.Quantity
+            Value of the Bose-Einstein integral.
+        """
+        bei = self.full() - self.upper()
+
+        return bei
+
+
     def upper(self) -> astropy.units.Quantity:
         """
         Upper incomplete Bose-Einstein integral.

--- a/src/ibei/models.py
+++ b/src/ibei/models.py
@@ -176,6 +176,11 @@ class BEI():
         elif self.reduced_chemical_potential >= self.reduced_energy_bound:
             bei = 0 * self.prefactor * np.math.factorial(self.order)
 
+        elif real_arg == 0:
+            # When the lower bound of the integral approaches
+            # infinity, the value of the integral approaches zero.
+            bei = 0 * self.prefactor * np.math.factorial(self.order)
+
         else:
             summand = 0
             for indx in range(1, self.order + 2):

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -324,6 +324,7 @@ def test_methods_regression(args, method_under_test, expected_output):
     )
 @pytest.mark.parametrize("method_under_test", 
         (
+            "lower",
             "upper",
             "full",
         )

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -208,6 +208,16 @@ class TestIssues():
 @pytest.mark.parametrize("args,method_under_test,expected_output", [
             (
                 {
+                    "order": 3,
+                    "energy_bound": 1.1,
+                    "temperature": 3000,
+                    "chemical_potential": 0,
+                },
+                "lower",
+                astropy.units.Quantity(2949919.81423557, "J/(m2 s)"),
+            ),
+            (
+                {
                     "order": 2,
                     "energy_bound": 1.1,
                     "temperature": 300,

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 import astropy.units
 import ibei
+import numpy as np
 import pytest
 
 from contextlib import nullcontext as does_not_raise
@@ -358,6 +359,22 @@ def test_consistency_upper_and_full_methods(valid_constructor_quantity_args):
     bei = ibei.models.BEI(**valid_constructor_quantity_args)
 
     assert astropy.units.allclose(bei.upper(), bei.full())
+
+
+def test_consistency_lower_and_full_methods(valid_constructor_quantity_args):
+    """
+    When `energy_bound` is `np.inf`, `BEI.lower` should equal `BEI.full`.
+
+    Notes
+    -----
+    This condition holds as long as `chemical_potential` equals zero.
+    """
+    valid_constructor_quantity_args["energy_bound"] = np.inf
+    valid_constructor_quantity_args["chemical_potential"] = 0.
+
+    bei = ibei.models.BEI(**valid_constructor_quantity_args)
+
+    assert astropy.units.allclose(bei.lower(), bei.full())
 
 
 @pytest.mark.parametrize("order,helper_method_name",[


### PR DESCRIPTION
# Overview
This PR closes #44. The changes required for this issue are pretty straightforward.