### PR TITLE
[53] Upload package artifact to testing PyPI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -2,7 +2,6 @@ name: Build and test package
 
 on:
   workflow_call:
-  push:
 
 jobs:
   build_test:

--- a/.github/workflows/upload-to-test-pypi.yml
+++ b/.github/workflows/upload-to-test-pypi.yml
@@ -1,4 +1,4 @@
-name: Upload package artifact to test.pypi.org
+name: Build, test, and publish package artifact to test.pypi.org
 
 on:
   push:

--- a/.github/workflows/upload-to-test-pypi.yml
+++ b/.github/workflows/upload-to-test-pypi.yml
@@ -26,3 +26,4 @@ jobs:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: ${{steps.download.outputs.download-path}}
+          skip_existing: true

--- a/.github/workflows/upload-to-test-pypi.yml
+++ b/.github/workflows/upload-to-test-pypi.yml
@@ -1,0 +1,28 @@
+name: Upload package artifact to test.pypi.org
+
+on:
+  push:
+
+jobs:
+  build-test:
+    name: Build and test package
+    uses: ./.github/workflows/build-test.yml
+
+  upload-package:
+    name: Upload package artifacts to test.pypi.org
+    runs-on: ubuntu-latest
+    needs:
+      - build-test
+    steps:
+      - name: Fetch package artifact
+        id: download
+        uses: actions/download-artifact@v3
+        with:
+          name: dist
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          packages_dir: ${{steps.download.outputs.download-path}}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@
 * 59: Update documentation.
 * 58: Cosmetic documentation edits.
 * 56: Update Python dependency to 3.10.
+* 53: Automatically post artifacts to PyPI.
 * 51: Write GitHub action to automatically run tests.
 * 50: Leverage `tox` to run tests.
 * 49: Refactor tests to use `pytest`.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@
 * 59: Update documentation.
 * 58: Cosmetic documentation edits.
 * 56: Update Python dependency to 3.10.
-* 53: Automatically post artifacts to PyPI.
+* 53: Automatically post artifacts to testing PyPI.
 * 51: Write GitHub action to automatically run tests.
 * 50: Leverage `tox` to run tests.
 * 49: Refactor tests to use `pytest`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,8 @@ Source = "https://github.com/jrsmith3/ibei"
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+
 [tool.hatch.build.hooks.vcs]
 version-file = "src/ibei/_version.py"

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -399,6 +399,13 @@ def test_consistency_full_and_helper_methods(order, helper_method_name, valid_co
     assert astropy.units.allclose(bei.full(), output)
 
 
+def test_fail():
+    """
+    Autofail to see if workflow runs
+    """
+    assert False
+
+
 # Pytest fixture definitions
 # ==========================
 @pytest.fixture

--- a/test/test_BEI.py
+++ b/test/test_BEI.py
@@ -399,13 +399,6 @@ def test_consistency_full_and_helper_methods(order, helper_method_name, valid_co
     assert astropy.units.allclose(bei.full(), output)
 
 
-def test_fail():
-    """
-    Autofail to see if workflow runs
-    """
-    assert False
-
-
 # Pytest fixture definitions
 # ==========================
 @pytest.fixture


### PR DESCRIPTION
# Overview
This PR closes #53.


# Deliverables
* [x] The workflow will push to the testing PyPI, not the main PyPI.
* [x] The workflow will not run if the testing failed.
* [x] The workflow will upload the package that was tested, it will not re-build the package.